### PR TITLE
Add optional test executable and enable Substrait C API tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
+add_subdirectory("test/c")
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -19,3 +19,9 @@ add_library_unity(test_substrait OBJECT ${ALL_SOURCES})
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_substrait>
     PARENT_SCOPE)
+
+# Add an executable target with main.cpp
+add_executable(test_substrait_exe $<TARGET_OBJECTS:test_substrait> main.cpp)
+
+# Link the executable with necessary libraries
+target_link_libraries(test_substrait_exe duckdb substrait_extension test_helpers)

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -20,8 +20,10 @@ set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_substrait>
     PARENT_SCOPE)
 
-# Add an executable target with main.cpp
-add_executable(test_substrait_exe $<TARGET_OBJECTS:test_substrait> main.cpp)
-
-# Link the executable with necessary libraries
-target_link_libraries(test_substrait_exe duckdb substrait_extension test_helpers)
+option(ENABLE_TEST_EXE "Build the optional test executable" OFF)
+if (ENABLE_TEST_EXE)
+    # Add an executable target with main.cpp
+    add_executable(test_substrait_exe $<TARGET_OBJECTS:test_substrait> main.cpp)
+    # Link the executable with necessary libraries
+    target_link_libraries(test_substrait_exe duckdb substrait_extension test_helpers)
+endif()

--- a/test/c/main.cpp
+++ b/test/c/main.cpp
@@ -1,0 +1,7 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+int main(int argc, char* argv[]) {
+  // Call Catch2's session to run tests
+  return Catch::Session().run(argc, argv);
+}

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -13,8 +13,6 @@ using namespace std;
 
 TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  SubstraitExtension substrait_extension;
-  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database
@@ -34,8 +32,6 @@ TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
 
 TEST_CASE("Test C Get and To Json-Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  SubstraitExtension substrait_extension;
-  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -13,7 +13,8 @@ using namespace std;
 
 TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  db.LoadExtension<duckdb::DUCKDB_EXTENSION_CLASS>();
+  SubstraitExtension substrait_extension;
+  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database
@@ -33,7 +34,8 @@ TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
 
 TEST_CASE("Test C Get and To Json-Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  db.LoadExtension<duckdb::DUCKDB_EXTENSION_CLASS>();
+  SubstraitExtension substrait_extension;
+  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -1,9 +1,6 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
-#include "duckdb/parser/parser.hpp"
-#include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/main/connection_manager.hpp"
-#include "substrait_extension.hpp"
 
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
Add optional test executable and enable Substrait C API tests

- Added an option `ENABLE_TEST_EXE` to build an optional test executable in `test/c/CMakeLists.txt`.
- Created a new `main.cpp` file to run C tests.
- Updated `test_substrait_c_api.cpp` to fix build errors and remove unused includes.
- Included the new test directory in the main `CMakeLists.txt`.