### PR TITLE
<DRAFT>Add substrait plan conversion for select from Virtual table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})
 
 set(PARAMETERS "-warnings")
 build_loadable_extension(${TARGET_NAME} ${PARAMETERS} ${EXTENSION_SOURCES})
+add_subdirectory("test/c")
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/src/include/to_substrait.hpp
+++ b/src/include/to_substrait.hpp
@@ -57,6 +57,8 @@ private:
 	substrait::Rel *TransformDistinct(LogicalOperator &dop);
 	substrait::Rel *TransformExcept(LogicalOperator &dop);
 	substrait::Rel *TransformIntersect(LogicalOperator &dop);
+	substrait::Rel *TransformExpressionGet(LogicalOperator &dop);
+	substrait::Expression_Literal ToExpressionLiteral(const substrait::Expression &expr);
 	static substrait::Rel *TransformDummyScan();
 	//! Methods to transform different LogicalGet Types (e.g., Table, Parquet)
 	//! To Substrait;

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -19,3 +19,9 @@ add_library_unity(test_substrait OBJECT ${ALL_SOURCES})
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_substrait>
     PARENT_SCOPE)
+
+# Add an executable target with main.cpp
+add_executable(test_substrait_exe $<TARGET_OBJECTS:test_substrait> main.cpp)
+
+# Link the executable with necessary libraries
+target_link_libraries(test_substrait_exe duckdb substrait_extension test_helpers)

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -20,8 +20,10 @@ set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:test_substrait>
     PARENT_SCOPE)
 
-# Add an executable target with main.cpp
-add_executable(test_substrait_exe $<TARGET_OBJECTS:test_substrait> main.cpp)
-
-# Link the executable with necessary libraries
-target_link_libraries(test_substrait_exe duckdb substrait_extension test_helpers)
+option(ENABLE_TEST_EXE "Build the optional test executable" OFF)
+if (ENABLE_TEST_EXE)
+    # Add an executable target with main.cpp
+    add_executable(test_substrait_exe $<TARGET_OBJECTS:test_substrait> main.cpp)
+    # Link the executable with necessary libraries
+    target_link_libraries(test_substrait_exe duckdb substrait_extension test_helpers)
+endif()

--- a/test/c/main.cpp
+++ b/test/c/main.cpp
@@ -1,0 +1,7 @@
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+int main(int argc, char* argv[]) {
+  // Call Catch2's session to run tests
+  return Catch::Session().run(argc, argv);
+}

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -13,8 +13,6 @@ using namespace std;
 
 TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  SubstraitExtension substrait_extension;
-  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database
@@ -34,8 +32,6 @@ TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
 
 TEST_CASE("Test C Get and To Json-Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  SubstraitExtension substrait_extension;
-  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -13,7 +13,8 @@ using namespace std;
 
 TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  db.LoadExtension<duckdb::DUCKDB_EXTENSION_CLASS>();
+  SubstraitExtension substrait_extension;
+  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database
@@ -33,7 +34,8 @@ TEST_CASE("Test C Get and To Substrait API", "[substrait-api]") {
 
 TEST_CASE("Test C Get and To Json-Substrait API", "[substrait-api]") {
   DuckDB db(nullptr);
-  db.LoadExtension<duckdb::DUCKDB_EXTENSION_CLASS>();
+  SubstraitExtension substrait_extension;
+  substrait_extension.Load(db);
   Connection con(db);
   con.EnableQueryVerification();
   // create the database

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -1,9 +1,6 @@
 #include "catch.hpp"
 #include "test_helpers.hpp"
-#include "duckdb/parser/parser.hpp"
-#include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/main/connection_manager.hpp"
-#include "substrait_extension.hpp"
 
 #include <chrono>
 #include <thread>

--- a/test/c/test_substrait_c_api.cpp
+++ b/test/c/test_substrait_c_api.cpp
@@ -45,3 +45,29 @@ TEST_CASE("Test C Get and To Json-Substrait API", "[substrait-api]") {
 
   REQUIRE_THROWS(con.FromSubstraitJSON("this is not valid"));
 }
+
+TEST_CASE("Test C Get and To Substrait API for Select from virtual table", "[substrait-api]") {
+    DuckDB db(nullptr);
+    Connection con(db);
+    con.EnableQueryVerification();
+
+
+    auto json = con.GetSubstrait("SELECT * FROM (VALUES (1, 2), (3, 4))");
+    auto result = con.FromSubstrait(json);
+    // number of rows selected are expected as result of insert
+    REQUIRE(CHECK_COLUMN(result, 0, {1, 3}));
+    REQUIRE(CHECK_COLUMN(result, 1, {2, 4}));
+}
+
+TEST_CASE("Test C Get and To JSON-Substrait API for Select from virtual table", "[substrait-api]") {
+    DuckDB db(nullptr);
+    Connection con(db);
+    con.EnableQueryVerification();
+
+
+    auto json = con.GetSubstraitJSON("SELECT * FROM (VALUES (1, 2), (3, 4))");
+    auto result = con.FromSubstraitJSON(json);
+    // number of rows selected are expected as result of insert
+    REQUIRE(CHECK_COLUMN(result, 0, {1, 3}));
+    REQUIRE(CHECK_COLUMN(result, 1, {2, 4}));
+}

--- a/test/python/test_substrait.py
+++ b/test/python/test_substrait.py
@@ -15,3 +15,28 @@ def test_roundtrip_substrait(require):
 
     pd.testing.assert_series_equal(query_result.df()["i"], expected)
 
+
+def test_roundtrip_proto_select_virtual_table(require):
+    connection = require('substrait')
+
+    res = connection.get_substrait("SELECT * FROM (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9))")
+    proto_bytes = res.fetchone()[0]
+
+    query_result = connection.from_substrait(proto_bytes)
+
+    expected = pd.Series(range(10), name="col0", dtype="int32")
+
+    pd.testing.assert_series_equal(query_result.df()["col0"], expected)
+
+
+def test_roundtrip_json_select_virtual_table(require):
+    connection = require('substrait')
+
+    res = connection.get_substrait_json("SELECT * FROM (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9))")
+    proto_bytes = res.fetchone()[0]
+
+    query_result = connection.from_substrait_json(proto_bytes)
+
+    expected = pd.Series(range(10), name="col0", dtype="int32")
+
+    pd.testing.assert_series_equal(query_result.df()["col0"], expected)


### PR DESCRIPTION
* This is pending because of CAST expression to literal conversion is not complete ([TODO here](https://github.com/sundeck-io/duckdb-substrait/pull/5/files#diff-fa39440d47b3a506fb57dc2b5995715aa97a0c378cf53044d66f6ea228e08582R1350))
* Added python test too which will pass.
* Unit test will fail because of unoptimized statement run which will add cast expression. 
* I will undraft after fixing cast expression to literal